### PR TITLE
修复一处配置文件读取时的错误

### DIFF
--- a/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs
+++ b/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs
@@ -188,6 +188,12 @@ namespace TboxWebdav.Server.AspNetCore.Models
                     return opt;
                 }
                 if (root.AuthMode == AppAuthMode.Custom || root.AuthMode == AppAuthMode.Mixed)
+                    if (root.Users == null)
+                    {
+                        opt.IsError = true;
+                        opt.Message = "使用 AuthMode: Custom 或 Mixed 时，必须使用 Users 指定用于 WebDav 服务认证的自定义用户。";
+                        return opt;
+                    }
                     foreach (var user in root.Users)
                     {
                         if (user.UserName == null)

--- a/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs
+++ b/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs
@@ -187,13 +187,7 @@ namespace TboxWebdav.Server.AspNetCore.Models
                     opt.Message = "使用 AuthMode: None 时，必须指定 Cookie 或者 UserToken 用于新云盘认证。";
                     return opt;
                 }
-                if (root.AuthMode == AppAuthMode.Custom || root.AuthMode == AppAuthMode.Mixed)
-                    if (root.Users == null)
-                    {
-                        opt.IsError = true;
-                        opt.Message = "使用 AuthMode: Custom 或 Mixed 时，必须使用 Users 指定用于 WebDav 服务认证的自定义用户。";
-                        return opt;
-                    }
+                if ((root.AuthMode == AppAuthMode.Custom || root.AuthMode == AppAuthMode.Mixed) && root.Users != null)
                     foreach (var user in root.Users)
                     {
                         if (user.UserName == null)


### PR DESCRIPTION
## 复现

假设用户使用以下配置文件：
```yaml
Port: 5047 # HTTP 服务监听端口
```

使用`./TboxWebdav.Server.AspNetCore -c ./TboxWebdav.yaml`运行，发生报错：`Object reference not set to an instance of an object.`

## 修复

debug 得到完整报错信息：

```
Unhandled exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at TboxWebdav.Server.AspNetCore.Models.AppCmdOptionBinder.ValidateValuesForFile(BindingContext bindingContext) in /home/runner/work/TboxWebdav/TboxWebdav/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs:line 189
   at TboxWebdav.Server.AspNetCore.Models.AppCmdOptionBinder.GetBoundValue(BindingContext bindingContext) in /home/runner/work/TboxWebdav/TboxWebdav/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs:line 86
<省略>
```

结论是判断`Users`字段不存在就好了。

对于`Custom`，这样做应该是预期行为，不过是否需要对`Users`为空提供警告可能值得考虑。
对于`Mixed`，我没看懂应该怎么用，如果不对还请修改。

## 题外话

另外，我写这个 PR 的时候感觉以下几点行为可能不利于 debug：
- 隐藏报错 stackTrace，也就是这里发生的只输出报错信息: https://github.com/1357310795/TboxWebdav/blob/4537e22adf241158783fe26661b8081f9bc45e94/TboxWebdav.Server.AspNetCore/Models/AppCmdOption.cs#L217-L221
- 未说明如何调整 log 输出级别：我不确定是否只要改`appsettings.json`，总之在文档里说明一下可能更好。
- 未构建 Debug 版本：其实我并不是很清楚，对 dotnet 应用来说，Debug 和 Release 是否有很大区别，不过在 https://github.com/1357310795/TboxWebdav/blob/4537e22adf241158783fe26661b8081f9bc45e94/.github/workflows/release_aspnetcore.yml#L13 加一个 Debug 构建，并且只作为 Actions Artifacts 上传应该不是坏事。